### PR TITLE
Fix to get the last testing version of grsec.

### DIFF
--- a/kernel/get-and-build.sh
+++ b/kernel/get-and-build.sh
@@ -17,7 +17,7 @@ fail() {
 GRSEC=$(curl http://grsecurity.net/test.php)
 [ -n "$GRSEC" ] || fail "get grsecurity page"
 
-PATCH=$(echo "$GRSEC" | grep -o 'grsecurity-[.0-9]*-[.0-9]*-[0-9]*\.patch' | sort -ru | head -n 1)
+PATCH=$(echo "$GRSEC" | grep -o 'test/grsecurity-[.0-9]*-[.0-9]*-[0-9]*\.patch' | sort -ru | head -n 1 | cut -c6-)
 [ -n "$PATCH" ] || fail "parse patch file from grsec page"
 
 wget -c "http://grsecurity.net/test/$PATCH" || fail "get $PATCH"


### PR DESCRIPTION
$ curl http://grsecurity.net/test.php | grep -o 'grsecurity-[.0-9]_-[.0-9]_-[0-9]*.patch' | sort -ru
grsecurity-3.0-3.2.54-201401272346.patch
 -> http://grsecurity.net/stable/grsecurity-3.0-3.2.54-201401272346.patch
grsecurity-3.0-3.13.0-201401272348.patch
 -> The version we want.
grsecurity-2.9.1-2.6.32.61-201312262018.patch

$ curl http://grsecurity.net/test.php | grep -o 'test/grsecurity-[.0-9]_-[.0-9]_-[0-9]*.patch' | sort -ru
test/grsecurity-3.0-3.13.0-201401272348.patch
